### PR TITLE
Added getOLMapExtent helper for NY SL, NY FC and Bogota buttons. Updated links for beta WME.

### DIFF
--- a/OpenOtherMaps.js
+++ b/OpenOtherMaps.js
@@ -406,15 +406,6 @@
         return new OpenLayers.LonLat(lon, lat);
     }
 
-    function getOLMapExtent() {
-        let extent = W.map.getExtent();
-        if (Array.isArray(extent)) {
-            extent = new OpenLayers.Bounds(extent);
-            extent.transform('EPSG:4326', 'EPSG:3857');
-        }
-        return extent;
-    }
-
     var insertPath = '.WazeControlPermalink';
     function LoadMapButtons(){
         $('#OOMMiDrive').remove();
@@ -585,7 +576,7 @@
             $(insertPath).prepend($sectionNYFC.html());
 
             $('#OOMNYFCImg').click(function(){
-                let e=getOLMapExtent();
+                let e=W.map.getOLExtent();
                 let geoNW=new OpenLayers.Geometry.Point(e.left,e.top);
                 let geoSE=new OpenLayers.Geometry.Point(e.right,e.bottom);
 
@@ -635,7 +626,7 @@
             $(insertPath).prepend($sectionNYSL.html());
 
             $('#OOMNYSLImg').click(function(){
-                let e=getOLMapExtent();
+                let e=W.map.getOLExtent();
                 let geoNW=new OpenLayers.Geometry.Point(e.left,e.top);
                 let geoSE=new OpenLayers.Geometry.Point(e.right,e.bottom);
 
@@ -965,8 +956,8 @@
 
             $(insertPath).prepend($sectionBogota.html());
             $('#OOMBogotaImg').click(function(){
-                var topleft= (new OpenLayers.LonLat(getOLMapExtent().left,getOLMapExtent().top));
-                var bottomright= (new OpenLayers.LonLat(getOLMapExtent().right,getOLMapExtent().bottom));
+                var topleft= (new OpenLayers.LonLat(W.map.getOLExtent().left,W.map.getOLExtent().top));
+                var bottomright= (new OpenLayers.LonLat(W.map.getOLExtent().right,W.map.getOLExtent().bottom));
 
                 let source = new proj4.Proj('EPSG:900913');
                 var topleft4686 = new proj4.toPoint([parseFloat(topleft.lon), parseFloat(topleft.lat)]);
@@ -1146,7 +1137,7 @@
             $(insertPath).prepend($section.html());
 
             $('#OOMMelvinImg').click(function(){
-                let extent = getOLMapExtent();
+                let extent = W.map.getOLExtent();
 
                 let sw = WazeWrap.Geometry.ConvertTo4326(extent.left, extent.bottom);
                 let ne = WazeWrap.Geometry.ConvertTo4326(extent.right, extent.top);
@@ -1346,7 +1337,7 @@
         //         if(settings.BurlON)
         //         {
         //             let $section = $("<div>", {style:"padding:8px 16px"});
-        //                 let e=getOLMapExtent();
+        //                 let e=W.map.getOLExtent();
         //                 let geoNW=new OpenLayers.Geometry.Point(e.left,e.top);
         //                 let geoSE=new OpenLayers.Geometry.Point(e.right,e.bottom);
         //             $section.html([
@@ -1365,7 +1356,7 @@
         //         if(settings.MiltON)
         //         {
         //             let $section = $("<div>", {style:"padding:8px 16px"});
-        //                 let e=getOLMapExtent();
+        //                 let e=W.map.getOLExtent();
         //                 let geoNW=new OpenLayers.Geometry.Point(e.left,e.top);
         //                 let geoSE=new OpenLayers.Geometry.Point(e.right,e.bottom);
         //             $section.html([

--- a/OpenOtherMaps.js
+++ b/OpenOtherMaps.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         WME Open Other Maps
 // @namespace    https://greasyfork.org/users/30701-justins83-waze
-// @version      2024.09.10.01
+// @version      2024.09.21.01
 // @description  Links for opening external resources at the WME location and WME from external resources
 // @author       JustinS83
 // @match        https://www.waze.com/editor*
@@ -54,7 +54,7 @@
     //var jqUI_CssSrc = GM_getResourceText("jqUI_CSS");
     //GM_addStyle(jqUI_CssSrc);
 
-    const updateMessage = `Added support for Geoportal DGU (Croatia)`;
+    const updateMessage = `Fixed NY FC, NY SL and Bogota.`;
 
     var settings = {};
     var wazerIcon = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEgAAABICAYAAABV7bNHAAAAAXNSR0IArs4c6QAACehJREFUeNrtXOlTVFcWpzJTU/kwf8F8nI8TNSGaVGKWSpllxkQzM2WcSWIq7IsoEhFlXyVgszVKs0QRmi0EBGUxLCLQsi8NzdaA0IhLEhNDAspoghHP3HObfnRLd9PvvdvQpNqqU1Y93rvvnF/fs593HRzW8B8APCUf02zNU0+6ykc0klz1ZIV8ZGJQrp6YJjRDaGGJZug18jftPRoJfYY8i2s4/J7+FY/f/EuuWuOrFXRyNndkAsQQXYOshWvi2hsSlNzp6afl6sl9RJh6IsyiWFBMElkb34HvwnfaPDCl6jt/lqs1AYTh21YDxdTOIu/EdyMPNgdMM8AfiY3wR9ux1sCsBGpiBnlBnmwCnHz11Ktkqw+tNzBG1G8IeVtHdYI/5aknTpGt/djmwFlWu8fII/K6puAUTdz4K3m50laBMQKUEnleI5XS7CDbd26jgKOncnPIu3Xdt3pyLwZyGw6cZQO+gDJYB5wRjYdVY5q120mLKAvznfO7AEcfJFY7CfV2I6uVOXUTbZPQ8m9Ig8zDcAv2bhg7WMOVJ17pgUMFlfBxihzeDpHCK37x8ML+aNjmHQVvBCTAruh0+Cg5F3zzK0Da2rcmIYCgOAkDLFZMpLb3gZOsCF72/Rz+9mkQL3r1s3hwOlVIgbUWSCgr7/SBRYScRIR6/3gmPOMUbCD0v8NOQcjZcsip74CLPSOgGNbAlZEpKGtVQUaVAiLzKmF3cOoKsN6PyYC4S+1WibgtTkswyRObW32hUsM+aR5scg4xAKXgcjfc+Pke3F8Ei2jqxznIb+iCj45nGQC1m6ihrHuAee5mUYKLmbCYF0mauohdiVv+1UNSoXX0msWgmKKO8evglZzHrbvVMxICy+oYq9qkvwX1HOEli9ALDbDZRbtrnnUNhZMXGuHuw0XR4OhTOwHqnYBEDijn9CKmpRKz9SQsOAld/GhJLWdr9kalw8g3d5gCo08zvzykNkwHEqozO5A0AebKpIIqgVE1Vzh745Ekh59//c1q4OiTtPwyB9LHUjmzyqTR8i2t6wp04WgPkEm3hBzmKrUana5p5UAKLm9gBdK+lQBhgV3AYu9GplHmdh5Lhu/nf1lTcHQUlnOe8vC8ZxSkdYn3boiFkdYM/2Q0qKyeMoa2Rzn1zbqAo7NJfz+aRHn5V2wWk2TWoKVEDNMhvovkDF+Flw7GUqYwsFsvcHTUNjrNqVpySy8DkDS++vanUohLp9vaPRy+u/dg3QFC+jAmk/LklFbIYhdVLLeDBXQ8d4afosyguzXGbIv6GsQUVsMl1fiqgv1EVARTjJSyBrg19z/BABU2dlOetvt9zsIOzdI2N/a7eacS/Wou5unV3FrB6PCtH2Czc+jSlg+mUbA5wfRjGkwrhAKEaYxuHWmbUjxIBBtMLVz5PhhR3USZeMk72iijVV3DBrkT/rLmBPsgMp2790WvKFFq9vaRBLoOOhAGqYerA52y4PmgW9ZXlAlvab5RJn98sAC7gqX0nrf8E1ZVm/L2AdjkpA00MfgTA5BvWhFdxzWjmIGaaSQOdFKC54P/SThLmYgvrjHJ6PyjxzB88weYW3hkkWA3Z+dh6s6saEOdWKoNPfbEn2FjqOkMDs8HseqHTGRdbLEJ76VPeQ2dlLd3QlIZ7KCJQQccVOL7IL4cmcD6jq0BVKscpbxh9ZJBdj/tIKS8gZU9ZEJW2WyW2W/v3oejX5TC9Mxdk/dgRVGs3dGnvmvfUt42u4YyKX84CGnpfJiUS5mILbpoltnrBBhHt3Bav6nuHqF2Sfc3DC4RmC0uoeBKklxWAKFD0HnETOWw6NaQIIA8z5RqPYUFgmGtecdhCb0fwUA3/Dot3gdz5ZHv7t1nqmbPuoZpf8D6NiYA8VaxmNoWbdnTPcKi8sa93xapK8cdtz+1AI5kltCo2ViQyYL+G61NObzPljFRMd5GOntwnOo4MtE+Nm1zhhpLvcgb9tyQV3FGWoCbp64+Suvqg86U2RxAaIcc3bRq9l6kDE52qIS7eSGBIs3mK7TlTmSEtQ1hQXX9Y8TmLbednnMPh/eiZJDCJ0fTBor8Uw1dPUjXKY3Kr7I5gJAaBq7Sfpx+Xvia/wl+qYaQZFVH2JeiMYdzCAze+N4mQdJm+fNQrFByIGFj0/JkVUC5wyCqXkpK/3E0Ge7c/9UmAUK+dgVp+dxxLIlfuUNowcxYV8MrJW/NuxqWgKNz+44e4ZDS2suvYCa05GpYH2rmCmjY+sEiujFm5x4+grq+MRJBN0B6lQIUJIgUIjSmMOdJXCUpqYXc+g5QXb9t9L7x2zOcDdpCwpLorxX8S65Ci/YrO6s1XPNwT0Tais4qCmFsYsPpRDZNSSwFB3O37T7Hn1gnmDYOZpcalpjSFDb1wDbPCG0bnHhabG4KLtoLbfus2ElVTZQZyhRJK5LLLlGmb88/gNcPxZmcAcJWtX6eZop6Jm9xhTVjhN60snMI3g1M4a5hsJio6BbX9hHTOHySEpq74c2g5OUBqAOxBACZgSDPE5v1HEli9a+hl1kNoL1RGQbPvLA/hhuWeJKwJu6S/iWcVo2KbxyKaT2bipH8CqrAcWmL69MbJFn1K6yiI3Yv+sRw1wNPnzMLDvb7N+kNYv3zeCZZp5okzudomLEMTAgdZkDnwbT1LGZ4wdwg1eEvqw0E0AmGpL/TthOw/GTF4J/xFa0rY1LrTOwTqh92TTEx1gfaWVbErbPVK5K77iayFm1yeEHs+IslJVqqXh4RsC81j9a1l1tD/OkVYtM+TSvkckIdhVY0Wmf8hcUAlSk6dq7WrLDPEC/0yckCcMksBheyA9yySsAr+xwckJ+Hz4qqad4X19AGH0jOmF0HVRZ7dlYboBI7gpczPAFZqjFI7VWDhHiT2LZBiGzph5DmPngrQmZSsJ2SXPD+utM81XSCV3UbbDsQa3QNDDEOltRBMgkDZP2jkD10lf0InpAhzgziJaJbByDgci/41HSZFvBiB+yWFoKjd/TynKFPLOzJKl8dHD3yqGyFN2OyYIt7+NJkSQi87J8InxTWrbjXr74HQhX9FDR0HEyGOPmOAQc29fESEMm1TAHuF1p4P/ckuZQ2gmdV26r3+dR20V3FZAxYyCA5vjyeqBT+WkfITjpY1y1aeKGEYBy+1ANB5IeLaVVBCtk92UPjbAfJWXyKgDYgc2AMTvap6RaXdA1DXMcQxJAcClUy/IoKwhRa+4QUhESECmpU0v8Dm5T0WvAShTX3k2f6iU1T0edjyTonOgchkawrVaohnaj66cHx1VWJ1acI9o9Z7J9DLTD7RNP+QZ39k0z7R71W/6jX/lm4/WAB+9EU9sNNbOlwE/vxOPYDluxHdNnMIW/Yd8PmJKtD3mijcyMf8mZSBQH+sNGOCfw/CkKxncyBj/UAAAAASUVORK5CYII=";
@@ -405,6 +405,15 @@
         return new OpenLayers.LonLat(lon, lat);
     }
 
+    function getOLMapExtent() {
+        let extent = W.map.getExtent();
+        if (Array.isArray(extent)) {
+            extent = new OpenLayers.Bounds(extent);
+            extent.transform('EPSG:4326', 'EPSG:3857');
+        }
+        return extent;
+    }
+
     var insertPath = '.WazeControlPermalink';
     function LoadMapButtons(){
         $('#OOMMiDrive').remove();
@@ -575,7 +584,7 @@
             $(insertPath).prepend($sectionNYFC.html());
 
             $('#OOMNYFCImg').click(function(){
-                let e=W.map.getExtent();
+                let e=getOLMapExtent();
                 let geoNW=new OpenLayers.Geometry.Point(e.left,e.top);
                 let geoSE=new OpenLayers.Geometry.Point(e.right,e.bottom);
 
@@ -625,7 +634,7 @@
             $(insertPath).prepend($sectionNYSL.html());
 
             $('#OOMNYSLImg').click(function(){
-                let e=W.map.getExtent();
+                let e=getOLMapExtent();
                 let geoNW=new OpenLayers.Geometry.Point(e.left,e.top);
                 let geoSE=new OpenLayers.Geometry.Point(e.right,e.bottom);
 
@@ -955,8 +964,8 @@
 
             $(insertPath).prepend($sectionBogota.html());
             $('#OOMBogotaImg').click(function(){
-                var topleft= (new OpenLayers.LonLat(W.map.getExtent().left,W.map.getExtent().top));
-                var bottomright= (new OpenLayers.LonLat(W.map.getExtent().right,W.map.getExtent().bottom));
+                var topleft= (new OpenLayers.LonLat(getOLMapExtent().left,getOLMapExtent().top));
+                var bottomright= (new OpenLayers.LonLat(getOLMapExtent().right,getOLMapExtent().bottom));
 
                 let source = new proj4.Proj('EPSG:900913');
                 var topleft4686 = new proj4.toPoint([parseFloat(topleft.lon), parseFloat(topleft.lat)]);
@@ -1136,7 +1145,7 @@
             $(insertPath).prepend($section.html());
 
             $('#OOMMelvinImg').click(function(){
-                let extent = W.map.getExtent();
+                let extent = getOLMapExtent();
 
                 let sw = WazeWrap.Geometry.ConvertTo4326(extent.left, extent.bottom);
                 let ne = WazeWrap.Geometry.ConvertTo4326(extent.right, extent.top);
@@ -1336,7 +1345,7 @@
         //         if(settings.BurlON)
         //         {
         //             let $section = $("<div>", {style:"padding:8px 16px"});
-        //                 let e=W.map.getExtent();
+        //                 let e=getOLMapExtent();
         //                 let geoNW=new OpenLayers.Geometry.Point(e.left,e.top);
         //                 let geoSE=new OpenLayers.Geometry.Point(e.right,e.bottom);
         //             $section.html([
@@ -1355,7 +1364,7 @@
         //         if(settings.MiltON)
         //         {
         //             let $section = $("<div>", {style:"padding:8px 16px"});
-        //                 let e=W.map.getExtent();
+        //                 let e=getOLMapExtent();
         //                 let geoNW=new OpenLayers.Geometry.Point(e.left,e.top);
         //                 let geoSE=new OpenLayers.Geometry.Point(e.right,e.bottom);
         //             $section.html([

--- a/OpenOtherMaps.js
+++ b/OpenOtherMaps.js
@@ -1,12 +1,13 @@
 // ==UserScript==
 // @name         WME Open Other Maps
 // @namespace    https://greasyfork.org/users/30701-justins83-waze
-// @version      2024.09.21.01
+// @version      2024.09.23.01
 // @description  Links for opening external resources at the WME location and WME from external resources
 // @author       JustinS83
 // @match        https://www.waze.com/editor*
 // @match        https://www.waze.com/*/editor*
-// @match        https://beta.waze.com*
+// @match        https://beta.waze.com/editor*
+// @match        https://beta.waze.com/*/editor*
 // @match        *://www.google.com/maps*
 // @match        *://maps.google.com*
 // @match        *wv511.org/*


### PR DESCRIPTION
NY SL, NY FC (and found during the change) Bogota buttons did not function, this uses an OpenLayers helper to get the extents (lifted from the FC Layer script).

Updated links for beta WME.